### PR TITLE
Run through `java` not `scala` runner

### DIFF
--- a/src/main/scala/ch/epfl/lamp/ScalaTestRunner.scala
+++ b/src/main/scala/ch/epfl/lamp/ScalaTestRunner.scala
@@ -132,7 +132,7 @@ object ScalaTestRunner {
     val runLog = out.toString()
 
     val summaryfileStr = outfileStr + testSummarySuffix
-    val summaryCmd = ("scala" ::
+    val summaryCmd = ("java" ::
       "-cp" :: classpathString ::
       "ch.epfl.lamp.grading.GradingSummaryRunner" ::
       outfileStr :: summaryfileStr :: Nil)


### PR DESCRIPTION
review @manojo
